### PR TITLE
Fix MobWardBlock not possible to place above height 254.

### DIFF
--- a/src/main/kotlin/net/barribob/boss/block/MobWardBlock.kt
+++ b/src/main/kotlin/net/barribob/boss/block/MobWardBlock.kt
@@ -140,7 +140,7 @@ class MobWardBlock(private val factory: (FabricBlockEntityTypeBuilder.Factory<Ch
 
     override fun getPlacementState(ctx: ItemPlacementContext): BlockState? {
         val blockPos = ctx.blockPos
-        return if (blockPos.y < 254 &&
+        return if (blockPos.y < ctx.world.topY - 2 &&
             ctx.world.getBlockState(blockPos.up()).canReplace(ctx) &&
             ctx.world.getBlockState(blockPos.up(2)).canReplace(ctx)
         ) {


### PR DESCRIPTION
Simple change to make the mob ward block possible to be placed above height 254. It also makes it compatible with datapacks that change the world max build height.